### PR TITLE
Declare License metadata field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
     version='0.0.20',
     description='PEP 561 type stubs for docutils',
     long_description=open('README.rst').read(),
+    classifiers=['License :: OSI Approved :: The Unlicense (Unlicense)'],
+    license='Unlicense',
     url='https://github.com/tk0miya/docutils-stubs',
     author='Takeshi KOMIYA, cocoatomo',
     author_email='i.tkomiya@gmail.com, cocoatomo77@gmail.com',


### PR DESCRIPTION
Resolve GH-36.  Usually the License field is ignored due to the consistency of use across different projects, but I suppose it helps discovery.